### PR TITLE
Fix: Projects page horizontal tab overflow at 320px (#39)

### DIFF
--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -28,15 +28,28 @@ export function Projects() {
           </p>
         </motion.div>
 
-        <div className="flex justify-center gap-4 mb-12 overflow-x-auto pb-4 ">
+        
+        <div
+          className="
+          flex gap-3 mb-12
+          overflow-x-auto
+          pb-4 px-4 md:px-0
+          w-full max-w-full
+          scroll-smooth
+          snap-x snap-mandatory
+          [-webkit-overflow-scrolling:touch]
+          [scroll-padding-left:1rem]
+          md:justify-center
+        "
+        >
           {categories.map((category) => (
             <button
               key={category}
               onClick={() => setSelectedCategory(category)}
-              className={`px-4 py-2 rounded-full capitalize transition-colors  ${
+              className={`shrink-0 snap-start px-4 py-2 rounded-full capitalize transition-colors ${
                 selectedCategory === category
                   ? 'bg-emerald-500 text-white'
-                  : 'bg-gray-100 text-black hover:bg-emerald-100  dark:bg-gray-800 dark:text-white'
+                  : 'bg-gray-100 text-black hover:bg-emerald-100 dark:bg-gray-800 dark:text-white'
               }`}
             >
               {category}


### PR DESCRIPTION
## Summary
This PR fixes the issue where the first tabs **("ALL" & "WEB")** on the Projects page was clipped or invisible at 320 px width.

### Changes
- Added horizontal padding (`px-4`) and scroll padding to the tab row
- Enabled horizontal auto-scroll with `overflow-x-auto`, `scroll-smooth`, and `snap-x`
- Added `shrink-0` and `snap-start` on tab buttons to prevent squishing
- Re-centered tabs on medium+ screens with `md:justify-center`

### Result
- All tabs fully visible at 320 px
- Smooth horizontal scroll
- No horizontal scrollbar on the entire page
- Layout unchanged for larger viewports

Fixes #39

I didn’t comment before working on this one since it was a simple overflow fix, but I’ll follow the proper “_comment before PR_” flow next time :D