### PR TITLE
 Fix(system-design): render intro article instead of raw HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^2.2.2",
         "@monaco-editor/react": "^4.6.0",
         "axios": "^1.7.9",
+        "dompurify": "^3.1.6",
         "firebase": "^11.6.0",
         "framer-motion": "^11.0.8",
         "lucide-react": "^0.344.0",
@@ -27,6 +28,7 @@
         "zwitch": "^2.0.4"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/react": "^18.2.56",
         "@types/react-dom": "^18.2.19",
         "@types/react-syntax-highlighter": "^15.5.11",
@@ -2346,6 +2348,16 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -2429,6 +2441,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3077,6 +3096,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/public/content/system-design/fundamentals/intro.md
+++ b/public/content/system-design/fundamentals/intro.md
@@ -1,0 +1,63 @@
+---
+title: "Introduction to System Design"
+description: "Understand the core principles, components, and trade-offs in designing scalable systems."
+pubDate: 2024-03-15
+category: "System Design"
+author: "Dev Elevate Team"
+tags: ["architecture", "scalability", "availability", "consistency"]
+---
+
+Designing reliable and scalable systems requires understanding how different components interact, the trade-offs involved, and how to evolve systems as requirements grow.
+
+---
+
+## What is System Design?
+
+System design is the process of defining the architecture, components, interfaces, and data for a system to satisfy specified requirements. It focuses on how parts work together at scale.
+
+### Key Goals
+
+- Scalability: Handle growth in users, data, and traffic
+- Reliability: Continue to operate correctly in the presence of failures
+- Availability: Minimize downtime and ensure responsiveness
+- Maintainability: Make the system easy to evolve and operate
+
+---
+
+## Core Building Blocks
+
+1. Clients and API Gateways
+2. Application Servers and Microservices
+3. Databases (SQL/NoSQL) and Caches (Redis/Memcached)
+4. Message Brokers and Event Streams (Kafka/RabbitMQ)
+5. Load Balancers and CDNs
+6. Observability (Logging, Metrics, Tracing)
+
+---
+
+## Common Trade-offs
+
+- Consistency vs. Availability (CAP theorem)
+- Latency vs. Throughput
+- Simplicity vs. Flexibility
+
+---
+
+## Example: Scaling a Read-Heavy App
+
+Start with a monolith and single database. As traffic increases:
+
+1. Add a cache layer for frequent reads
+2. Introduce read replicas
+3. Split services by domain (user, content, analytics)
+4. Use an event bus for asynchronous processing
+
+---
+
+## Next Steps
+
+- Learn scalability patterns
+- Explore microservices and service decomposition
+- Practice designing systems with real-world constraints
+
+> Tip: Always start with requirements and constraints before picking tools.


### PR DESCRIPTION
---Added missing markdown file public/content/system-design/fundamentals/intro.md to match the [systemDesign]category entry.
---Updated [ArticleLayout] fetch logic to guard against HTML fallbacks (e.g., SPA serving [index.html], preventing raw HTML from being displayed.
---Maintains frontmatter parsing and dark-mode styles; shows a friendly error if the content path is incorrect.