### PR TITLE
Added 'Copy code' button to code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "zwitch": "^2.0.4"
       },
       "devDependencies": {
+        "@types/babel__traverse": "^7.28.0",
+        "@types/node": "^24.8.1",
         "@types/react": "^18.2.56",
         "@types/react-dom": "^18.2.19",
         "@types/react-syntax-highlighter": "^15.5.11",
@@ -338,11 +340,10 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
-      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -3015,13 +3016,12 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/debug": {
@@ -3073,12 +3073,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
-      "license": "MIT",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.14.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5228,7 +5227,6 @@
       "version": "0.344.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
       "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
-      "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
@@ -7712,10 +7710,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "zwitch": "^2.0.4"
   },
   "devDependencies": {
+    "@types/babel__traverse": "^7.28.0",
+    "@types/node": "^24.8.1",
     "@types/react": "^18.2.56",
     "@types/react-dom": "^18.2.19",
     "@types/react-syntax-highlighter": "^15.5.11",

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Copy } from 'lucide-react';
 
 export interface CodeBlockProps {
   code: string;
@@ -8,24 +9,23 @@ export interface CodeBlockProps {
   showLineNumbers?: boolean;
 }
 
-export const CodeBlock: React.FC<CodeBlockProps> = ({ 
-  code, 
-  language, 
-  showLineNumbers = false 
-}) => {
+export const CodeBlock: React.FC<CodeBlockProps> = ({
+  code,
+  language,
+  showLineNumbers = false,
+}: CodeBlockProps) => {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
-    // Function to check current theme
     const checkTheme = () => {
       const htmlElement = document.documentElement;
       setIsDarkMode(htmlElement.classList.contains('dark'));
     };
 
-    // Check initial theme
     checkTheme();
 
-    // Create observer to watch for theme changes
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
@@ -34,24 +34,101 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({
       });
     });
 
-    // Observe changes to the html element's class attribute
     observer.observe(document.documentElement, {
       attributes: true,
-      attributeFilter: ['class']
+      attributeFilter: ['class'],
     });
 
     return () => observer.disconnect();
   }, []);
-  
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
   return (
-    <div style={{
-      border: isDarkMode ? '1px solid #374151' : '1px solid #e5e7eb',
-      borderRadius: '12px',
-      boxShadow: '0 2px 8px 0 rgba(0,0,0,0.04)',
-      background: isDarkMode ? '#1f2937' : '#ffffff',
-      margin: '1rem 0',
-      overflow: 'auto',
-    }}>
+    <div
+      style={{
+        position: 'relative',
+        border: isDarkMode ? '1px solid #374151' : '1px solid #e5e7eb',
+        borderRadius: '12px',
+        boxShadow: '0 2px 8px 0 rgba(0,0,0,0.04)',
+        background: isDarkMode ? '#1f2937' : '#ffffff',
+        margin: '1rem 0',
+        overflow: 'auto',
+      }}
+      className="group"
+    >
+      {/* ✅ Copy Icon + Tooltip (below the icon) */}
+      <div
+        onClick={handleCopy}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{
+          position: 'absolute',
+          top: '10px',
+          right: '10px',
+          cursor: 'pointer',
+          background: isDarkMode ? '#374151' : '#f3f4f6',
+          borderRadius: '8px',
+          padding: '6px 10px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          transition: 'all 0.2s ease',
+          fontSize: '0.8rem',
+          fontWeight: 500,
+        }}
+      >
+        {copied ? (
+          <span
+            style={{
+              color: isDarkMode ? '#10B981' : '#047857',
+              fontWeight: 600,
+              transition: 'opacity 0.3s ease',
+            }}
+          >
+            Copied!
+          </span>
+        ) : (
+          <Copy
+            size={16}
+            color={isDarkMode ? '#e5e7eb' : '#111827'}
+            style={{ transition: 'opacity 0.3s ease' }}
+          />
+        )}
+
+        {/* 💬 Tooltip BELOW icon */}
+        {!copied && hovered && (
+          <span
+            style={{
+              position: 'absolute',
+              bottom: '-28px', // 👈 Now appears below
+              right: '0',
+              background: isDarkMode ? '#374151' : '#111827',
+              color: '#fff',
+              fontSize: '0.75rem',
+              padding: '4px 8px',
+              borderRadius: '6px',
+              whiteSpace: 'nowrap',
+              opacity: hovered ? 1 : 0,
+              transition: 'opacity 0.25s ease, transform 0.25s ease',
+              transform: hovered ? 'translateY(2px)' : 'translateY(8px)',
+              pointerEvents: 'none',
+            }}
+          >
+            Copy code
+          </span>
+        )}
+      </div>
+
+      {/* 💻 Syntax Highlighted Code */}
       <SyntaxHighlighter
         language={language}
         style={isDarkMode ? vscDarkPlus : vs}
@@ -69,7 +146,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({
             color: isDarkMode ? '#e5e7eb' : '#374151',
             fontFamily: 'Monaco, Menlo, "Ubuntu Mono", monospace',
             background: 'transparent',
-          }
+          },
         }}
       >
         {code}


### PR DESCRIPTION
**Description**

This PR introduces a Copy Code feature to all code blocks. It allows users to easily copy code snippets with a single click and provides a smooth visual confirmation (“Copied!”) upon success.

**Key Features**

- Added a copy icon (📋) to the top-right corner of each code block.
- Displays a tooltip “Copy code” when hovering over the icon.
- On click, shows “Copied!” text for 2 seconds before reverting back to the icon.
- Automatically adapts to light and dark themes.
- Includes a subtle fade-in/out animation for the tooltip.

**Implementation Details**

- Updated the CodeBlock.tsx component inside src/components/.
- Integrated lucide-react for the copy icon.
- Used navigator.clipboard for copying text.
- Styled inline for theme consistency and clean UI transitions.

**Why This Change**

Improves user experience by allowing quick and intuitive code copying, especially helpful for documentation or tutorials.

**Screenshots**

https://github.com/user-attachments/assets/207b079d-25c9-4838-aa2a-9fbebf8ca8c0

Resolves #90 

